### PR TITLE
Update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ git go-clone <repo>
 Move the current repo to a git-organized directory
 
 ```bash
-$ git go-organize <repo>
+$ git go-organize
 ```
 
 ## Examples
@@ -33,7 +33,7 @@ $ git go-organize <repo>
 ```bash
 $ git go-clone https://github.com/rot26/git-organized.git
 # Is the same as
-$ git clone https://github.com/rot26/git-organized.git ${GOPATH}/src/github.com/rot26/git-organized
+$ git clone https://github.com/rot26/git-organized.git ${GOPATH:-HOME}/src/github.com/rot26/git-organized
 ```
 
 ### Organize a repo
@@ -42,7 +42,7 @@ $ git clone https://github.com/rot26/git-organized.git ${GOPATH}/src/github.com/
 # At old path
 $ git go-organize /random/path/to/repo
 # Is the same as
-$ mv /random/path/to/repo ${GOPATH}/src/github.com/rot26/git-organized && cd $_
+$ mv /random/path/to/repo ${GOPATH:-HOME}/src/github.com/rot26/git-organized && cd $_
 ```
 
 ## Valid Characters

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Get organized by moving and managing your repos in the go-lang fashion
 Curl the script into your path
 
 ```bash
-curl -s https://raw.githubusercontent.com/rot26/git-organized/main/git-go-clone.sh -o /usr/local/bin/git-go-clone && chmod u+x /usr/local/bin/git-go-clone
-curl -s https://raw.githubusercontent.com/rot26/git-organized/main/git-go-organize.sh -o /usr/local/bin/git-go-organize && chmod u+x /usr/local/bin/git-go-organize
+curl -s https://raw.githubusercontent.com/rot26/git-organized/refs/heads/master/src/git-go-clone -o /usr/local/bin/git-go-clone && chmod u+x /usr/local/bin/git-go-clone
+curl -s https://raw.githubusercontent.com/rot26/git-organized/refs/heads/master/src/git-go-organize.sh -o /usr/local/bin/git-go-organize && chmod u+x /usr/local/bin/git-go-organize
 ```
 
 

--- a/src/git-go-clone
+++ b/src/git-go-clone
@@ -3,6 +3,7 @@
 set -e # Exit on error
 
 SCRIPT_PATH=$(realpath "$(dirname "$0")")
+declare VERSION="1.0.0"
 
 function remote_to_path() {
   local remote_url=$1
@@ -25,6 +26,7 @@ usage() {
     echo "Options:"
     echo "  -h, --help                   Display this help message"
     echo "  -d, --dry-run                Print the repository URL without cloning"
+    echo "  -v, --version                Display the version of the script"
     exit 1
 }
 
@@ -36,6 +38,9 @@ while [[ "$@" -gt 0 ]]; do
     case $1 in
         -h|--help)
             usage
+            ;;
+        -v|--version)
+            echo "Version: $VERSION"
             ;;
         -d|--dry-run)
             DRY_RUN=true

--- a/src/git-go-clone
+++ b/src/git-go-clone
@@ -25,6 +25,10 @@ usage() {
     echo "Usage: $0 [options] <repository-url>"
     echo "Options:"
     echo "  -h, --help                   Display this help message"
+    echo "  -p, --path-override <path>   Override the path with the specified value."
+    echo "                               Alternatively use GIT_ORGANIZED_PATH environment variable"
+    echo "  -o <name>, --origin <name>   Use <name> instead of 'origin' to track the upstream repository"
+    echo "                               Only used with path-override"
     echo "  -d, --dry-run                Print the repository URL without cloning"
     echo "  -v, --version                Display the version of the script"
     exit 1
@@ -41,10 +45,21 @@ while [[ "$@" -gt 0 ]]; do
             ;;
         -v|--version)
             echo "Version: $VERSION"
+            exit 0
             ;;
         -d|--dry-run)
             DRY_RUN=true
+            shift
             ;;
+        -p|--path-override)
+            GIT_ORGANIZED_PATH="$2"
+            shift 2
+            ;;
+        -o|--origin)
+            ORIGIN_NAME="$2"
+            shift 2
+            ;;
+
         *)
             if [[ "$1" == -* ]]; then
                 OPTIONS="$OPTIONS $1"
@@ -65,12 +80,17 @@ if [ -z "$REPO_URL" ]; then
     usage
 fi
 
-
 # Define a prefix of ${GOPATH}. If GOPATH is not set, set to ${HOME}.
 PREFIX=${GOPATH:-$HOME}/src
 
-# Get the path to the repository
-REPO_PATH="${PREFIX}/$(remote_to_path "${REPO_URL}")"
+# If GIT_ORGANIZED_PATH is set via -p, --path-override, or environment variable, use it.
+if [[ -n "$GIT_ORGANIZED_PATH" ]]; then
+    REPO_PATH="${PREFIX}/${GIT_ORGANIZED_PATH}"
+# Else leverage the repo url to determine the path
+else
+    # Get the path to the repository
+    REPO_PATH="${PREFIX}/$(remote_to_path "${REPO_URL}")"
+fi
 
 # Check if the repository already exists
 if [ -d "${REPO_PATH}" ]; then
@@ -79,6 +99,7 @@ if [ -d "${REPO_PATH}" ]; then
     exit 1
 fi
 
+# Clone the repository with options
 # Handle dry-run option
 if [ "$DRY_RUN" = true ]; then
     echo "Dry run: Repository URL is $REPO_URL"
@@ -87,9 +108,15 @@ if [ "$DRY_RUN" = true ]; then
 fi
 
 # Clone the repository with options
-git clone $OPTIONS "$REPO_URL" "${REPO_PATH}" || {
+git clone $OPTIONS "${REPO_URL}" "${REPO_PATH}" || {
     echo "Error: Failed to clone repository."
     exit 1
 }
+
+# Set git config if GIT_ORGANIZED_PATH is set
+if [[ -n "$GIT_ORGANIZED_PATH" ]]; then
+    cd "${REPO_PATH}"
+    git config --local git-organized.${ORIGIN_NAME:-"origin"}.path "$GIT_ORGANIZED_PATH"
+fi
 
 echo "Successfully cloned repository: $REPO_URL"

--- a/src/git-go-organize
+++ b/src/git-go-organize
@@ -135,6 +135,11 @@ fi
 # Create the parent directory if it does not exist
 mkdir -p "$(dirname ${REPO_PATH})"
 
+# If the path override is set, update the git config
+if [[ -n "$GIT_ORGANIZED_PATH" ]]; then
+    git config --set git-organized.${ORIGIN_NAME:-"origin"}.path) "${GIT_ORGANIZED_PATH}"
+fi
+
 # Move the current project to the new location
 mv -r ${OPTIONS} \
     "${OLD_PATH_ROOT}" \

--- a/src/git-go-organize
+++ b/src/git-go-organize
@@ -29,6 +29,8 @@ usage() {
     echo "Options:"
     echo "  -h, --help                   Display this help message"
     echo "  -d, --dry-run                Print the repository URL without cloning"
+    echo "  -p, --path-override <path>   Override the path with the specified value."
+    echo "                               Alternatively use GIT_ORGANIZED_PATH environment variable"
     echo "  -o <name>, --origin <name>   Use <name> instead of 'origin' to track the upstream repository"
     echo "  -s, --symlink                Create symlinks for other remotes"
     echo "  -v, --version                Display the version of the script"
@@ -52,9 +54,13 @@ while [[ "$#" -gt 0 ]]; do
         -d|--dry-run)
             DRY_RUN=true
             ;;
+        -p|--path-override)
+            GIT_ORGANIZED_PATH="$2"
+            shift 2
+            ;;
         -o|--origin)
             ORIGIN_NAME="$2"
-            shift
+            shift 2
             ;;
         -s|--symlink)
             SYMLINK=true
@@ -71,14 +77,22 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+
 # Get the repository URL using the specified origin name
-REPO_URL=$(git config --get remote.${ORIGIN_NAME}.url)
+REPO_URL=$(git config --get remote.${ORIGIN_NAME:-"origin"}.url)
 
 # Define a prefix of ${GOPATH}. If GOPATH is not set, set to ${HOME}.
 PREFIX="${GOPATH:-$HOME}/src"
 
-# Get the path to the repository
-REPO_PATH="${PREFIX}/$(remote_to_path "${REPO_URL}")"
+# If GIT_ORGANIZED_PATH is set via -p, --path-override, or environment variable, use it.
+if [[ -n "$GIT_ORGANIZED_PATH" ]]; then
+    REPO_PATH="${PREFIX}/${GIT_ORGANIZED_PATH}"
+elif PATH_OVERRIDE=$(git config --get git-organized.${ORIGIN_NAME:-"origin"}.path); then
+    REPO_PATH="${PREFIX}/${PATH_OVERRIDE}"
+else
+    # Get the path to the repository
+    REPO_PATH="${PREFIX}/$(remote_to_path "${REPO_URL}")"
+fi
 
 # Create a list to store tuples of remote name, remote URL, and remote path
 declare -a REMOTE_TUPLES
@@ -88,7 +102,12 @@ if [ "$SYMLINK" = true ]; then
     for remote in "$(git remote)"; do
         if [ "$remote" != "$ORIGIN_NAME" ]; then
             REMOTE_URL="$(git config --get remote.${remote}.url)"
-            REMOTE_PATH="${REPO_PATH}/$(basename "${REMOTE_URL}" .git)"
+            if REMOTE_PATH_OVERRIDE=$(git config --get git-organized.${remote}.path); then
+                REMOTE_PATH="${PREFIX}/${REMOTE_PATH_OVERRIDE}"
+            else
+                # Get the path to the repository
+                REMOTE_PATH="${PREFIX}/$(remote_to_path "${REMOTE_URL}")"
+            fi
             REMOTE_TUPLES+=("$remote" "$REMOTE_URL" "$REMOTE_PATH")
         fi
     done

--- a/src/git-go-organize
+++ b/src/git-go-organize
@@ -3,6 +3,7 @@
 set -e # Exit on error
 
 SCRIPT_PATH=$(realpath "$(dirname "$0")")
+declare VERSION="1.0.0"
 
 function remote_to_path() {
   local remote_url=$1
@@ -30,6 +31,7 @@ usage() {
     echo "  -d, --dry-run                Print the repository URL without cloning"
     echo "  -o <name>, --origin <name>   Use <name> instead of 'origin' to track the upstream repository"
     echo "  -s, --symlink                Create symlinks for other remotes"
+    echo "  -v, --version                Display the version of the script"
     exit 1
 }
 
@@ -43,6 +45,9 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         -h|--help)
             usage
+            ;;
+        -v|--version)
+            echo "Version: $VERSION"
             ;;
         -d|--dry-run)
             DRY_RUN=true


### PR DESCRIPTION
This pull request includes several updates to the `README.md` file and enhancements to the `git-go-clone` and `git-go-organize` scripts to improve usability and functionality.

### Documentation Updates:

* Updated the `curl` commands in the `README.md` to use the correct paths for downloading scripts. (`README.md`, [README.mdL10-R11](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R11))
* Simplified the command usage examples in the `README.md` by removing unnecessary parameters. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45)

### Script Enhancements:

* Added version declaration (`VERSION="1.0.0"`) to both `git-go-clone` and `git-go-organize` scripts. (`src/git-go-clone`, [[1]](diffhunk://#diff-0e0af5b8ff2df39b60b9c93e66e0743e5a3e2c0bccfd96b415d381c88a938059R6); `src/git-go-organize`, [[2]](diffhunk://#diff-c6338bd8a2279659e2acd600553cc2a1fed01d349f0e56ad54652e64868c046cR6)
* Enhanced the `usage` function in both scripts to include new options for path override, origin name, and version display. (`src/git-go-clone`, [[1]](diffhunk://#diff-0e0af5b8ff2df39b60b9c93e66e0743e5a3e2c0bccfd96b415d381c88a938059R28-R33); `src/git-go-organize`, [[2]](diffhunk://#diff-c6338bd8a2279659e2acd600553cc2a1fed01d349f0e56ad54652e64868c046cR32-R36)
* Implemented new command-line options for path override (`-p, --path-override`), origin name (`-o, --origin`), and version display (`-v, --version`). (`src/git-go-clone`, [[1]](diffhunk://#diff-0e0af5b8ff2df39b60b9c93e66e0743e5a3e2c0bccfd96b415d381c88a938059R46-R62); `src/git-go-organize`, [[2]](diffhunk://#diff-c6338bd8a2279659e2acd600553cc2a1fed01d349f0e56ad54652e64868c046cR51-R63)
* Updated logic to handle the path override and origin name options, ensuring the correct repository paths are used and configurations are set. (`src/git-go-clone`, [[1]](diffhunk://#diff-0e0af5b8ff2df39b60b9c93e66e0743e5a3e2c0bccfd96b415d381c88a938059L63-R93) [[2]](diffhunk://#diff-0e0af5b8ff2df39b60b9c93e66e0743e5a3e2c0bccfd96b415d381c88a938059R102) [[3]](diffhunk://#diff-0e0af5b8ff2df39b60b9c93e66e0743e5a3e2c0bccfd96b415d381c88a938059L85-R121); `src/git-go-organize`, [[4]](diffhunk://#diff-c6338bd8a2279659e2acd600553cc2a1fed01d349f0e56ad54652e64868c046cR80-R95) [[5]](diffhunk://#diff-c6338bd8a2279659e2acd600553cc2a1fed01d349f0e56ad54652e64868c046cL86-R110) [[6]](diffhunk://#diff-c6338bd8a2279659e2acd600553cc2a1fed01d349f0e56ad54652e64868c046cR138-R142)